### PR TITLE
[BULK UPDATES] DocuTune - Fix build validation issues: docs-link-absolute

### DIFF
--- a/api-docs/cntk-2.4/docs-ref-autogen/cntk/cntk.debugging.profiler.yml
+++ b/api-docs/cntk-2.4/docs-ref-autogen/cntk/cntk.debugging.profiler.yml
@@ -18,7 +18,7 @@ functions:
 
     the profiler is not enabled after start
 
-    ([example](https://docs.microsoft.com/en-us/cognitive-toolkit/BrainScript-and-Python-Performance-Profiler#for-python)).'
+    ([example](/cognitive-toolkit/BrainScript-and-Python-Performance-Profiler#for-python)).'
   signature: start_profiler(dir='profiler', sync_gpu=True, reserve_mem=33554432)
   parameters:
   - name: dir

--- a/api-docs/cntk-2.4/docs-ref-autogen/cntk/cntk.io.MinibatchSource.yml
+++ b/api-docs/cntk-2.4/docs-ref-autogen/cntk/cntk.io.MinibatchSource.yml
@@ -30,7 +30,7 @@ constructor:
 
       **Important:**
 
-      Click [here](https://docs.microsoft.com/en-us/cognitive-toolkit/BrainScript-epochSize-and-Python-epoch_size-in-CNTK)
+      Click [here](/cognitive-toolkit/BrainScript-epochSize-and-Python-epoch_size-in-CNTK)
 
       for a description of input and label samples.'
     types:
@@ -150,7 +150,7 @@ methods:
 
       **Important:**
 
-      Click [here](https://docs.microsoft.com/en-us/cognitive-toolkit/BrainScript-minibatchSize-and-Python-minibatch_size_in_samples-in-CNTK)
+      Click [here](/cognitive-toolkit/BrainScript-minibatchSize-and-Python-minibatch_size_in_samples-in-CNTK)
       for a full description of this parameter.'
     isRequired: true
     types:

--- a/api-docs/cntk-2.4/docs-ref-autogen/cntk/cntk.io.MinibatchSourceFromData.yml
+++ b/api-docs/cntk-2.4/docs-ref-autogen/cntk/cntk.io.MinibatchSourceFromData.yml
@@ -54,7 +54,7 @@ constructor:
 
       **Important:**
 
-      Click [here](https://docs.microsoft.com/en-us/cognitive-toolkit/BrainScript-epochSize-and-Python-epoch_size-in-CNTK)
+      Click [here](/cognitive-toolkit/BrainScript-epochSize-and-Python-epoch_size-in-CNTK)
 
       for a description of input and label samples.'
     types:

--- a/api-docs/cntk-2.4/docs-ref-autogen/cntk/cntk.io.yml
+++ b/api-docs/cntk-2.4/docs-ref-autogen/cntk/cntk.io.yml
@@ -22,7 +22,7 @@ functions:
     types:
     - <xref:str>
   - name: streams
-  seeAlsoContent: '  [Base64ImageDeserializer options](https://docs.microsoft.com/en-us/cognitive-toolkit/BrainScript-and-Python---Understanding-and-Extending-Readers#base64imagedeserializer-options)
+  seeAlsoContent: '  [Base64ImageDeserializer options](/cognitive-toolkit/BrainScript-and-Python---Understanding-and-Extending-Readers#base64imagedeserializer-options)
 
     '
 - uid: cntk.io.CBFDeserializer
@@ -41,7 +41,7 @@ functions:
 
       an input stream.'
     defaultValue: '{}'
-  seeAlsoContent: '  [CNTKBinaryReader format](https://docs.microsoft.com/en-us/cognitive-toolkit/BrainScript-CNTKBinary-Reader)
+  seeAlsoContent: '  [CNTKBinaryReader format](/cognitive-toolkit/BrainScript-CNTKBinary-Reader)
 
     '
 - uid: cntk.io.CTFDeserializer
@@ -65,7 +65,7 @@ functions:
       names to <xref:cntk.io.StreamDef> objects. Each StreamDef object configures
 
       an input stream.'
-  seeAlsoContent: '  [CNTKTextReader format](https://docs.microsoft.com/en-us/cognitive-toolkit/BrainScript-CNTKTextFormat-Reader)
+  seeAlsoContent: '  [CNTKTextReader format](/cognitive-toolkit/BrainScript-CNTKTextFormat-Reader)
 
     '
 - uid: cntk.io.HTKFeatureDeserializer
@@ -120,7 +120,7 @@ functions:
     types:
     - <xref:str>
   - name: streams
-  seeAlsoContent: '  [Image reader definition](https://docs.microsoft.com/en-us/cognitive-toolkit/BrainScript-Image-reader)
+  seeAlsoContent: '  [Image reader definition](/cognitive-toolkit/BrainScript-Image-reader)
 
     '
 - uid: cntk.io.LatticeDeserializer
@@ -239,7 +239,7 @@ functions:
     types:
     - <xref:dict>
   return:
-    description: 'String representation in [CNTKTextReader format](https://docs.microsoft.com/en-us/cognitive-toolkit/BrainScript-CNTKTextFormat-Reader)'
+    description: 'String representation in [CNTKTextReader format](/cognitive-toolkit/BrainScript-CNTKTextFormat-Reader)'
     types:
     - <xref:str>
 classes:

--- a/api-docs/cntk-2.4/docs-ref-autogen/cntk/cntk.learners.yml
+++ b/api-docs/cntk-2.4/docs-ref-autogen/cntk/cntk.learners.yml
@@ -243,7 +243,7 @@ functions:
     description: 'momentum schedule. Note that this is the beta1 parameter in the
       Adam paper [1].
 
-      For additional information, please refer to the [this CNTK Wiki article](https://docs.microsoft.com/en-us/cognitive-toolkit/BrainScript-SGD-Block#converting-learning-rate-and-momentum-parameters-from-other-toolkits).'
+      For additional information, please refer to the [this CNTK Wiki article](/cognitive-toolkit/BrainScript-SGD-Block#converting-learning-rate-and-momentum-parameters-from-other-toolkits).'
     types:
     - <xref:float>, <xref:list>, <xref:output of cntk.learners.momentum_schedule>
   - name: unit_gain
@@ -362,7 +362,7 @@ functions:
   - name: momentum
     description: 'momentum schedule.
 
-      For additional information, please refer to the [this CNTK Wiki article](https://docs.microsoft.com/en-us/cognitive-toolkit/BrainScript-SGD-Block#converting-learning-rate-and-momentum-parameters-from-other-toolkits).'
+      For additional information, please refer to the [this CNTK Wiki article](/cognitive-toolkit/BrainScript-SGD-Block#converting-learning-rate-and-momentum-parameters-from-other-toolkits).'
     types:
     - <xref:float>, <xref:list>, <xref:output of cntk.learners.momentum_schedule>
   - name: unit_gain
@@ -727,7 +727,7 @@ functions:
   - name: momentum
     description: 'momentum schedule.
 
-      For additional information, please refer to the [this CNTK Wiki article](https://docs.microsoft.com/en-us/cognitive-toolkit/BrainScript-SGD-Block#converting-learning-rate-and-momentum-parameters-from-other-toolkits).'
+      For additional information, please refer to the [this CNTK Wiki article](/cognitive-toolkit/BrainScript-SGD-Block#converting-learning-rate-and-momentum-parameters-from-other-toolkits).'
     types:
     - <xref:float>, <xref:list>, <xref:output of <xref:cntk.learners.momentum_schedule>>
   - name: unit_gain
@@ -827,7 +827,7 @@ functions:
   - name: momentum
     description: 'momentum schedule.
 
-      For additional information, please refer to the [this CNTK Wiki article](https://docs.microsoft.com/en-us/cognitive-toolkit/BrainScript-SGD-Block#converting-learning-rate-and-momentum-parameters-from-other-toolkits).'
+      For additional information, please refer to the [this CNTK Wiki article](/cognitive-toolkit/BrainScript-SGD-Block#converting-learning-rate-and-momentum-parameters-from-other-toolkits).'
     types:
     - <xref:float>, <xref:list>, <xref:output of <xref:cntk.learners.momentum_schedule>>
   - name: unit_gain

--- a/api-docs/cntk-2.5.1/docs-ref-autogen/cntk/cntk.debugging.profiler.yml
+++ b/api-docs/cntk-2.5.1/docs-ref-autogen/cntk/cntk.debugging.profiler.yml
@@ -18,7 +18,7 @@ functions:
 
     the profiler is not enabled after start
 
-    ([example](https://docs.microsoft.com/en-us/cognitive-toolkit/BrainScript-and-Python-Performance-Profiler#for-python)).'
+    ([example](/cognitive-toolkit/BrainScript-and-Python-Performance-Profiler#for-python)).'
   signature: start_profiler(dir='profiler', sync_gpu=True, reserve_mem=33554432)
   parameters:
   - name: dir

--- a/api-docs/cntk-2.5.1/docs-ref-autogen/cntk/cntk.io.MinibatchSource.yml
+++ b/api-docs/cntk-2.5.1/docs-ref-autogen/cntk/cntk.io.MinibatchSource.yml
@@ -30,7 +30,7 @@ constructor:
 
       **Important:**
 
-      Click [here](https://docs.microsoft.com/en-us/cognitive-toolkit/BrainScript-epochSize-and-Python-epoch_size-in-CNTK)
+      Click [here](/cognitive-toolkit/BrainScript-epochSize-and-Python-epoch_size-in-CNTK)
 
       for a description of input and label samples.'
     types:
@@ -150,7 +150,7 @@ methods:
 
       **Important:**
 
-      Click [here](https://docs.microsoft.com/en-us/cognitive-toolkit/BrainScript-minibatchSize-and-Python-minibatch_size_in_samples-in-CNTK)
+      Click [here](/cognitive-toolkit/BrainScript-minibatchSize-and-Python-minibatch_size_in_samples-in-CNTK)
       for a full description of this parameter.'
     isRequired: true
     types:

--- a/api-docs/cntk-2.5.1/docs-ref-autogen/cntk/cntk.io.MinibatchSourceFromData.yml
+++ b/api-docs/cntk-2.5.1/docs-ref-autogen/cntk/cntk.io.MinibatchSourceFromData.yml
@@ -54,7 +54,7 @@ constructor:
 
       **Important:**
 
-      Click [here](https://docs.microsoft.com/en-us/cognitive-toolkit/BrainScript-epochSize-and-Python-epoch_size-in-CNTK)
+      Click [here](/cognitive-toolkit/BrainScript-epochSize-and-Python-epoch_size-in-CNTK)
 
       for a description of input and label samples.'
     types:

--- a/api-docs/cntk-2.5.1/docs-ref-autogen/cntk/cntk.io.yml
+++ b/api-docs/cntk-2.5.1/docs-ref-autogen/cntk/cntk.io.yml
@@ -22,7 +22,7 @@ functions:
     types:
     - <xref:str>
   - name: streams
-  seeAlsoContent: '  [Base64ImageDeserializer options](https://docs.microsoft.com/en-us/cognitive-toolkit/BrainScript-and-Python---Understanding-and-Extending-Readers#base64imagedeserializer-options)
+  seeAlsoContent: '  [Base64ImageDeserializer options](/cognitive-toolkit/BrainScript-and-Python---Understanding-and-Extending-Readers#base64imagedeserializer-options)
 
     '
 - uid: cntk.io.CBFDeserializer
@@ -41,7 +41,7 @@ functions:
 
       an input stream.'
     defaultValue: '{}'
-  seeAlsoContent: '  [CNTKBinaryReader format](https://docs.microsoft.com/en-us/cognitive-toolkit/BrainScript-CNTKBinary-Reader)
+  seeAlsoContent: '  [CNTKBinaryReader format](/cognitive-toolkit/BrainScript-CNTKBinary-Reader)
 
     '
 - uid: cntk.io.CTFDeserializer
@@ -65,7 +65,7 @@ functions:
       names to <xref:cntk.io.StreamDef> objects. Each StreamDef object configures
 
       an input stream.'
-  seeAlsoContent: '  [CNTKTextReader format](https://docs.microsoft.com/en-us/cognitive-toolkit/BrainScript-CNTKTextFormat-Reader)
+  seeAlsoContent: '  [CNTKTextReader format](/cognitive-toolkit/BrainScript-CNTKTextFormat-Reader)
 
     '
 - uid: cntk.io.HTKFeatureDeserializer
@@ -120,7 +120,7 @@ functions:
     types:
     - <xref:str>
   - name: streams
-  seeAlsoContent: '  [Image reader definition](https://docs.microsoft.com/en-us/cognitive-toolkit/BrainScript-Image-reader)
+  seeAlsoContent: '  [Image reader definition](/cognitive-toolkit/BrainScript-Image-reader)
 
     '
 - uid: cntk.io.LatticeDeserializer
@@ -239,7 +239,7 @@ functions:
     types:
     - <xref:dict>
   return:
-    description: 'String representation in [CNTKTextReader format](https://docs.microsoft.com/en-us/cognitive-toolkit/BrainScript-CNTKTextFormat-Reader)'
+    description: 'String representation in [CNTKTextReader format](/cognitive-toolkit/BrainScript-CNTKTextFormat-Reader)'
     types:
     - <xref:str>
 classes:


### PR DESCRIPTION
[BULK UPDATE] DocuTune - Fix build validation issues: docs-link-absolute

**Global effort to fix build validation errors**

The Microsoft Skilling team is fixing build validation errors and specific brand inconsistencies in Microsoft technical documentation for the rest of FY23 Q1. This will help address various accessibility, security, and usability issues. This PR was generated using DocuTune. It includes only targeted fixes and minor formatting adjustments.

DocuTune PRs improve quality of technical content by finding and automatically correcting a broad set of issues only where the correction is suitable. Please review within five business days and merge or comment in the PR with any changes you'd like to see. Thank you!

CorrelationId: 0df9c2d6-63f8-4d1e-8b57-b33611a06514
InitiativeId: docutune-build-validation-issues-2022-05
PointOfContact: Alex Buck
